### PR TITLE
add details on local port forwarding to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,11 @@ This project generates Love Notes for you using AI.
 2. create .env file for OpenAI Key
 3. run `npm run dev`
 4. open in browser at `localhost:3000`
+
+
+For port issues in Gitpod: 
+1. open Gitpod in your browser
+2. run `npm run start` (if it's not already running)
+3. add this in your terminal  ` gp ports expose 3000`
+4. check that you get this output from the command above: `Forwarding traffic: 0.0.0.0:3001 -> 127.0.0.1:3000`
+5. Open Gitpod in VSCode


### PR DESCRIPTION
This should be the view in the Gitpod Termina:
<img width="383" alt="Screen Shot 2023-07-12 at 12 04 04 AM" src="https://github.com/QR-Loved/mvp/assets/54756529/b6013e77-d40b-4f44-aac1-c2c285ddd5a6">

After opening Gitpod in VSCode:
1. Click the link associated with the correct ports
2. Forward the port using the command in the README
3. Run `gp ports protocol 3000:https` (optional)

You may need to refresh the workspace: 
Run `gp validate`

